### PR TITLE
feat: claude marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,13 @@
+{
+  "name": "apimatic",
+  "owner": {
+    "name": "APIMatic",
+    "email": "developer@apimatic.io"
+  },
+  "plugins": [
+    {
+      "name": "context-matic",
+      "source": "./"
+    }
+  ]
+}


### PR DESCRIPTION
allows user to add context-matic directly from github repo

https://code.claude.com/docs/en/discover-plugins#add-from-github


```bash
claude
/plugin marketplace add apimatic/context-matic
/plugin install context-matic
```